### PR TITLE
Set symfony default rest-api-format to json

### DIFF
--- a/upgrade-to-5.1/symfony/config/config.yml
+++ b/upgrade-to-5.1/symfony/config/config.yml
@@ -8,3 +8,9 @@ parameters:
 framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
+
+fos_rest:
+    format_listener:
+        enabled: true
+        rules:
+            - { path: '^/api/', fallback_format: json }


### PR DESCRIPTION
That way, APIs that return data using `View::create()`, from `FOS\RestBundle\View\View` e.g. [kwc-menu-api](https://github.com/koala-framework/kwc-menu-api) work out of the box.